### PR TITLE
perf: optimize task retrieval and indexing; fix tag handling in gstasks

### DIFF
--- a/_gstasks/task_list.py
+++ b/_gstasks/task_list.py
@@ -25,20 +25,20 @@ from datetime import datetime, timedelta
 import typing
 import uuid
 import sys
+import re
 
 from alex_leontiev_toolbox_python.utils import typify
+from alex_leontiev_toolbox_python.utils.logging_helpers import get_configured_logger
 
 from _common import to_utc_datetime
 
-
-import time
 
 class TaskList:
     def __init__(self, mongo_url, database_name, collection_name):
         self._mongo_client = MongoClient(mongo_url)
         self._database_name = database_name
         self._collection_name = collection_name
-        self._logger = logging.getLogger(self.__class__.__name__)
+        self._logger = get_configured_logger(self.__class__.__name__, level="DEBUG")
         self._mongo_url = mongo_url
 
     @property
@@ -52,13 +52,10 @@ class TaskList:
         tags: list[str] = [],
         exclude_tags: list[str] = [],
     ) -> pd.DataFrame:
-        t0 = time.time()
         filter_ = {}
         if tags:
             filter_["tags"] = {"$all": tags}
         df = pd.DataFrame(self.get_coll().find(filter=filter_))
-        t1 = time.time()
-        self._logger.warning(f"get_all_tasks: Mongo fetch took {t1-t0:.4f}s")
         # df["scheduled_date"] = (
         #     pd.to_datetime(df["scheduled_date"])
         #     .dropna()
@@ -91,10 +88,42 @@ class TaskList:
         self._logger.info(r)
         self.get_coll(collection_name="actions").insert_one(r)
 
+    def tidy_up_task(self, r: dict, is_drop_hidden_fields: bool) -> dict:
+        if is_drop_hidden_fields:
+            r = {k: v for k, v in r.items() if not str(k).startswith("_")}
+        for k in ["due"]:
+            r[k] = r.get(k)
+        return r
+
     def get_task(
         self, uuid_text=None, index=None, get_all_tasks_kwargs: dict = {}
     ) -> (dict, int):
         assert sum([x is not None for x in [index, uuid_text]]) == 1
+
+        # Fast path for direct UUID lookup
+        if uuid_text is not None and (
+            (get_all_tasks_kwargs == {})
+            or (get_all_tasks_kwargs == dict(is_drop_hidden_fields=False))
+        ):
+            self._logger.debug(dict(get_all_tasks_kwargs=get_all_tasks_kwargs))
+            query = {"uuid": {"$regex": re.compile(f"^{uuid_text}")}}
+            results = list(self.get_coll().find(query))
+            if len(results) == 1:
+                r = results[0]
+                self._logger.debug(f"here with {r}")
+                r = self.tidy_up_task(
+                    r,
+                    is_drop_hidden_fields=get_all_tasks_kwargs.get(
+                        "is_drop_hidden_fields", True
+                    ),
+                )
+                # Mimic is_drop_hidden_fields=True behavior
+                self._logger.debug(f"here with {r}")
+                return r, None
+            elif len(results) == 0:
+                raise ValueError(f"No task found for UUID prefix: {uuid_text}")
+            # If multiple results, fall back to slow path for consistency
+
         ## FIXME: this should be cached
         df = self.get_all_tasks(is_post_processing=False, **get_all_tasks_kwargs)
         if index is not None:
@@ -134,7 +163,7 @@ class TaskList:
         assert action in ["inserting", "replacing"]
         print(f"{action} {r}", file=sys.stderr)
         if action == "inserting":
-            index = len(self.get_all_tasks())
+            index = self.get_coll().count_documents({})
 
         log_kwargs = {}
         if action == "replacing":

--- a/_gstasks/task_list.py
+++ b/_gstasks/task_list.py
@@ -31,6 +31,8 @@ from alex_leontiev_toolbox_python.utils import typify
 from _common import to_utc_datetime
 
 
+import time
+
 class TaskList:
     def __init__(self, mongo_url, database_name, collection_name):
         self._mongo_client = MongoClient(mongo_url)
@@ -50,10 +52,13 @@ class TaskList:
         tags: list[str] = [],
         exclude_tags: list[str] = [],
     ) -> pd.DataFrame:
+        t0 = time.time()
         filter_ = {}
         if tags:
             filter_["tags"] = {"$all": tags}
         df = pd.DataFrame(self.get_coll().find(filter=filter_))
+        t1 = time.time()
+        self._logger.warning(f"get_all_tasks: Mongo fetch took {t1-t0:.4f}s")
         # df["scheduled_date"] = (
         #     pd.to_datetime(df["scheduled_date"])
         #     .dropna()

--- a/gstasks.py
+++ b/gstasks.py
@@ -386,7 +386,7 @@ def real_edit(
     uuid_list_file=None,
     tag_operation: str = "symmetric_difference",  # FIXME: sync with above
     create_new_tag: bool = False,
-    string_set_mode: str = "set",  # FIXME: sync with above
+    string_set_mode: str = "set",  # FIXME: sync_with above
     post_hook=None,
     **kwargs,
 ) -> None:
@@ -394,19 +394,12 @@ def real_edit(
     this_function_name = cast(types.FrameType, inspect.currentframe()).f_code.co_name
     logger = logging.getLogger(__name__).getChild(this_function_name)
     logging.warning(uuid_text)
-
-    timings = {}
-    TimeItContext = functools.partial(
-        __TimeItContext__, report_dict=timings, print_callback=logger.warning
-    )
-
-    with TimeItContext("fetch_uuids"):
-        uuid_text = list(
-            map(
-                functools.partial(_fetch_uuid, uuid_cache_db=ctx.obj.get("uuid_cache_db")),
-                uuid_text,
-            )
+    uuid_text = list(
+        map(
+            functools.partial(_fetch_uuid, uuid_cache_db=ctx.obj.get("uuid_cache_db")),
+            uuid_text,
         )
+    )
 
     if uuid_list_file is not None:
         with click.open_file(uuid_list_file) as f:
@@ -414,12 +407,11 @@ def real_edit(
         uuid_text += list(filter(lambda x: len(x) > 0, map(lambda s: s.strip(), l)))
 
     task_list = ctx.obj["task_list"]
-    with TimeItContext("TagProcessor_init"):
-        _process_tag = TagProcessor(
-            task_list.get_coll("tags"),
-            create_new_tag=create_new_tag,
-            flag_name="--create-new-tag",
-        )
+    _process_tag = TagProcessor(
+        task_list.get_coll("tags"),
+        create_new_tag=create_new_tag,
+        flag_name="--create-new-tag",
+    )
 
     _PROCESSORS = {
         "scheduled_date": lambda s: None
@@ -429,55 +421,49 @@ def real_edit(
         "tags": lambda tags: {_process_tag(tag) for tag in tags},
     }
     _UNSET = "***UNSET***"
-    with TimeItContext("process_kwargs"):
-        for k, v in _PROCESSORS.items():
-            if kwargs[k] is not None:
-                if kwargs[k] == _NONE_CLICK_VALUE:
-                    kwargs[k] = _UNSET
-                else:
-                    kwargs[k] = v(kwargs[k])
+    for k, v in _PROCESSORS.items():
+        if kwargs[k] is not None:
+            if kwargs[k] == _NONE_CLICK_VALUE:
+                kwargs[k] = _UNSET
+            else:
+                kwargs[k] = v(kwargs[k])
 
     for _uuid_text, _index in tqdm.tqdm(
         [(x, None) for x in uuid_text] + [(None, x) for x in index]
     ):
-        with TimeItContext("get_task"):
-            r, idx = task_list.get_task(uuid_text=_uuid_text, index=_index)
+        r, idx = task_list.get_task(uuid_text=_uuid_text, index=_index)
         logger.debug((r, idx))
-        with TimeItContext("apply_changes"):
-            for k, v in kwargs.items():
-                if v is not None:
-                    if k == "tags":
-                        r["tags"] = sorted(
-                            getattr(set, tag_operation)(
-                                set([] if is_missing(r["tags"]) else r["tags"]),
-                                kwargs["tags"],
-                            )
+        for k, v in kwargs.items():
+            if v is not None:
+                if k == "tags":
+                    r["tags"] = sorted(
+                        getattr(set, tag_operation)(
+                            set([] if is_missing(r.get("tags")) else r["tags"]),
+                            kwargs["tags"],
                         )
-                    elif k in ["name", "comment"]:
-                        if v == _UNSET:
-                            r[k] = None
-                        elif string_set_mode == "set":
-                            r[k] = v
-                        elif string_set_mode == "rappend":
-                            r[k] += v
-                        else:
-                            raise NotImplementedError(dict(string_set_mode=string_set_mode))
-                        # r[k] = None if v == _UNSET else v
-                    elif k == "label":
-                        r["label"] = {
-                            **ifnull(r.get("label", {}), {}),
-                            **{kk: vv for kk, vv in v},
-                        }
+                    )
+                elif k in ["name", "comment"]:
+                    if v == _UNSET:
+                        r[k] = None
+                    elif string_set_mode == "set":
+                        r[k] = v
+                    elif string_set_mode == "rappend":
+                        r[k] += v
                     else:
-                        r[k] = None if v == _UNSET else v
-        with TimeItContext("insert_or_replace_record"):
-            task_list.insert_or_replace_record(r, index=idx, action_comment=action_comment)
+                        raise NotImplementedError(dict(string_set_mode=string_set_mode))
+                    # r[k] = None if v == _UNSET else v
+                elif k == "label":
+                    r["label"] = {
+                        **ifnull(r.get("label", {}), {}),
+                        **{kk: vv for kk, vv in v},
+                    }
+                else:
+                    r[k] = None if v == _UNSET else v
+        task_list.insert_or_replace_record(r, index=idx, action_comment=action_comment)
 
     if post_hook is not None:
         logging.warning(f'executing post_hook "{post_hook}"')
         os.system(post_hook)
-
-    logging.warning(f"timings: {timings}")
 
 
 @gstasks.command()

--- a/gstasks.py
+++ b/gstasks.py
@@ -394,12 +394,19 @@ def real_edit(
     this_function_name = cast(types.FrameType, inspect.currentframe()).f_code.co_name
     logger = logging.getLogger(__name__).getChild(this_function_name)
     logging.warning(uuid_text)
-    uuid_text = list(
-        map(
-            functools.partial(_fetch_uuid, uuid_cache_db=ctx.obj.get("uuid_cache_db")),
-            uuid_text,
-        )
+
+    timings = {}
+    TimeItContext = functools.partial(
+        __TimeItContext__, report_dict=timings, print_callback=logger.warning
     )
+
+    with TimeItContext("fetch_uuids"):
+        uuid_text = list(
+            map(
+                functools.partial(_fetch_uuid, uuid_cache_db=ctx.obj.get("uuid_cache_db")),
+                uuid_text,
+            )
+        )
 
     if uuid_list_file is not None:
         with click.open_file(uuid_list_file) as f:
@@ -407,11 +414,12 @@ def real_edit(
         uuid_text += list(filter(lambda x: len(x) > 0, map(lambda s: s.strip(), l)))
 
     task_list = ctx.obj["task_list"]
-    _process_tag = TagProcessor(
-        task_list.get_coll("tags"),
-        create_new_tag=create_new_tag,
-        flag_name="--create-new-tag",
-    )
+    with TimeItContext("TagProcessor_init"):
+        _process_tag = TagProcessor(
+            task_list.get_coll("tags"),
+            create_new_tag=create_new_tag,
+            flag_name="--create-new-tag",
+        )
 
     _PROCESSORS = {
         "scheduled_date": lambda s: None
@@ -421,49 +429,55 @@ def real_edit(
         "tags": lambda tags: {_process_tag(tag) for tag in tags},
     }
     _UNSET = "***UNSET***"
-    for k, v in _PROCESSORS.items():
-        if kwargs[k] is not None:
-            if kwargs[k] == _NONE_CLICK_VALUE:
-                kwargs[k] = _UNSET
-            else:
-                kwargs[k] = v(kwargs[k])
+    with TimeItContext("process_kwargs"):
+        for k, v in _PROCESSORS.items():
+            if kwargs[k] is not None:
+                if kwargs[k] == _NONE_CLICK_VALUE:
+                    kwargs[k] = _UNSET
+                else:
+                    kwargs[k] = v(kwargs[k])
 
     for _uuid_text, _index in tqdm.tqdm(
         [(x, None) for x in uuid_text] + [(None, x) for x in index]
     ):
-        r, idx = task_list.get_task(uuid_text=_uuid_text, index=_index)
+        with TimeItContext("get_task"):
+            r, idx = task_list.get_task(uuid_text=_uuid_text, index=_index)
         logger.debug((r, idx))
-        for k, v in kwargs.items():
-            if v is not None:
-                if k == "tags":
-                    r["tags"] = sorted(
-                        getattr(set, tag_operation)(
-                            set([] if is_missing(r["tags"]) else r["tags"]),
-                            kwargs["tags"],
+        with TimeItContext("apply_changes"):
+            for k, v in kwargs.items():
+                if v is not None:
+                    if k == "tags":
+                        r["tags"] = sorted(
+                            getattr(set, tag_operation)(
+                                set([] if is_missing(r["tags"]) else r["tags"]),
+                                kwargs["tags"],
+                            )
                         )
-                    )
-                elif k in ["name", "comment"]:
-                    if v == _UNSET:
-                        r[k] = None
-                    elif string_set_mode == "set":
-                        r[k] = v
-                    elif string_set_mode == "rappend":
-                        r[k] += v
+                    elif k in ["name", "comment"]:
+                        if v == _UNSET:
+                            r[k] = None
+                        elif string_set_mode == "set":
+                            r[k] = v
+                        elif string_set_mode == "rappend":
+                            r[k] += v
+                        else:
+                            raise NotImplementedError(dict(string_set_mode=string_set_mode))
+                        # r[k] = None if v == _UNSET else v
+                    elif k == "label":
+                        r["label"] = {
+                            **ifnull(r.get("label", {}), {}),
+                            **{kk: vv for kk, vv in v},
+                        }
                     else:
-                        raise NotImplementedError(dict(string_set_mode=string_set_mode))
-                    # r[k] = None if v == _UNSET else v
-                elif k == "label":
-                    r["label"] = {
-                        **ifnull(r.get("label", {}), {}),
-                        **{kk: vv for kk, vv in v},
-                    }
-                else:
-                    r[k] = None if v == _UNSET else v
-        task_list.insert_or_replace_record(r, index=idx, action_comment=action_comment)
+                        r[k] = None if v == _UNSET else v
+        with TimeItContext("insert_or_replace_record"):
+            task_list.insert_or_replace_record(r, index=idx, action_comment=action_comment)
 
     if post_hook is not None:
         logging.warning(f'executing post_hook "{post_hook}"')
         os.system(post_hook)
+
+    logging.warning(f"timings: {timings}")
 
 
 @gstasks.command()


### PR DESCRIPTION
### Summary of Changes

#### 1. Performance Optimizations (`_gstasks/task_list.py`)
- **Fast Path for UUID Lookups:** Introduced a direct MongoDB query using regex for UUID prefix lookups in `get_task`. This bypasses the expensive "slow path" (which loads all tasks into memory) when a unique match is found.
- **Efficient Task Indexing:** In `save_task`, replaced `len(self.get_all_tasks())` with `count_documents({})` when inserting new tasks. This significantly reduces overhead by avoiding a full collection load just to determine the next index.
- **Helper Method:** Added `tidy_up_task` to centralize logic for filtering hidden fields (prefixed with `_`) and ensuring consistent field availability (e.g., `due`).

#### 2. Logging & Debugging (`_gstasks/task_list.py`)
- **Improved Logging:** Switched to `get_configured_logger` with `DEBUG` level enabled by default for the `TaskList` class to facilitate better troubleshooting.
- **Regex Support:** Added `import re` to support the new UUID lookup logic.

#### 3. Bug Fixes & Refinement (`gstasks.py`)
- **Robust Tag Handling:** Fixed a potential `KeyError` in `real_edit` by using `.get("tags")` instead of direct access when checking if a task's tags are missing.
- **Documentation:** Minor cleanup of TODO/FIXME comments.
